### PR TITLE
fix: use badge from master branch

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 [![Chat at https://discord.gg/sgak4e5NKv](https://img.shields.io/badge/chat-on%20Discord-%234cb697)](https://discord.gg/sgak4e5NKv)
 [![Chat at https://gitter.im/javalin-io/general](https://img.shields.io/badge/chat-on%20Slack-%234cb697)](https://join.slack.com/t/javalin-io/shared_invite/zt-1hwdevskx-ftMobDhGxhW0I268B7Ub~w)
-[![CI](https://github.com/javalin/javalin/workflows/Test%20all%20JDKs%20on%20all%20OSes/badge.svg)](https://github.com/javalin/javalin/actions)
+[![CI](https://github.com/javalin/javalin/actions/workflows/main.yml/badge.svg?branch=master)]([https://github.com/javalin/javalin/actions](https://github.com/javalin/javalin/actions/workflows/main.yml?query=branch%3Amaster))
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Maven](https://img.shields.io/maven-central/v/io.javalin/javalin.svg)](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22io.javalin%22%20AND%20a%3A%22javalin%22)
 


### PR DESCRIPTION
The badge we use in the profile is based on CI status from any branch:

![image](https://github.com/user-attachments/assets/2493d065-65d9-4eb9-b438-4eb1674e5110)

![image](https://github.com/user-attachments/assets/e91a1ab7-67c6-4213-babb-e83d8fe67459)

Let's lock it to the master branch only